### PR TITLE
bug: parseIso doesn't correctly parse date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - '11'
 
 before_install:
-  - export TZ=Australia/Canberra
+  - export TZ=Europe/Paris
 
 install:
   - npm i

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ node_js:
   - '10'
   - '11'
 
+before_install:
+  - export TZ=Australia/Canberra
+
 install:
   - npm i
   - cd browser-test && npm i && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ notifications:
 
 node_js:
   - '8'
+  - '9'
+  - '10'
+  - '11'
 
 install:
   - npm i

--- a/src/parse/parse-iso.test.ts
+++ b/src/parse/parse-iso.test.ts
@@ -94,8 +94,10 @@ describe('parseIso', function() {
 	});
 
 	it('correct parse Zulu timezone', function() {
-		const d = parseIso('2017-06-01T12:34:56.789Z');
-		assert.equal(d && d.toISOString(), '2017-06-01T12:34:56.789Z');
+		['2017-06-01T12:34:56.789Z', '2038-10-31T12:10:20.672Z'].forEach(date => {
+			const d = parseIso(date);
+			assert.equal(d && d.toISOString(), date);
+		});
 	});
 
 	it('correct throw if not parsed', function() {


### PR DESCRIPTION
Reproduction for a bug in `parseIso`

If you are okay with another dev-dependency I think that adding property tests via https://github.com/dubzzz/fast-check could catch those parsing errors

I can add some more if you want, It'll look like this
```js
  it('returns the same string after parsing it then converting back to string', () => {
    fc.assert(fc.property(fc.date(), anyDate => {
      const anyDateISOString = anyDate.toISOString();
      expect(parseIso(anyDateISOString).toISOString()).toEqual(anyDateISOString);
    }));
  });
```